### PR TITLE
fix symbol, provide bundler configs for devnet

### DIFF
--- a/scripts/6.createNFTs.ts
+++ b/scripts/6.createNFTs.ts
@@ -57,7 +57,11 @@ import { Metaplex, bundlrStorage, keypairIdentity } from "@metaplex-foundation/j
     // set our keypair to use, and pay for the transaction
     .use(keypairIdentity(payer))
     // define a storage mechanism to upload with
-    .use(bundlrStorage());
+    .use(bundlrStorage({
+      address: "https://devnet.bundlr.network",
+      providerUrl: "https://api.devnet.solana.com",
+      timeout: 60000
+    }));
 
   // upload the JSON metadata
   const { uri } = await metaplex.nfts().uploadMetadata(metadata);
@@ -68,7 +72,7 @@ import { Metaplex, bundlrStorage, keypairIdentity } from "@metaplex-foundation/j
   const { nft, response } = await metaplex.nfts().create({
     uri,
     name: metadata.name,
-    symbol: metadata.name,
+    symbol: metadata.symbol,
 
     // `sellerFeeBasisPoints` is the royalty that you can define on nft
     sellerFeeBasisPoints: 500, // Represents 5.00%.


### PR DESCRIPTION
This PR fixes two issues
- Symbol too long, due to misplacing name as symbol logged as
```
Payer address: 4WUnUjrs8DYBuz9kuZRRyjhofcGhYrLgvTBbMS5Ad56p
==== Local PublicKeys loaded ====
Token's mint address: H2K1jngMNz4Mevc3bBLhH2KGzKFbPQhaNyTNpVGnVy8k
https://explorer.solana.com/address/H2K1jngMNz4Mevc3bBLhH2KGzKFbPQhaNyTNpVGnVy8k?cluster=devnet

https://arweave.net/Xd9SbZYKoRTPzdIdqtykpsS9McmqV_IdQnB1q19Rd-w
/home/saber/code/workshop-nyc-basics/node_modules/@metaplex-foundation/js/src/plugins/rpcModule/RpcClient.ts:448
      ? new ParsedProgramError(program, resolvedError, error.logs)
        ^                                      
ParsedProgramError: The program [TokenMetadataProgram] at address [metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s] raised an error of code [12] that translates to "Symbol too long".

Source: Program > TokenMetadataProgram [metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s]

Caused By: SymbolTooLong: Symbol too long

```
- Bundler error tx not funded due to missing configs on bundlr instance, fixed by passing devnet configs [here](https://github.com/solana-developers/workshop-nyc-basics/pull/1/files#diff-426845c8474fd32a6d3cf917386a5d7663663708bc2ad32f5673e687cdbd5a21R61)